### PR TITLE
fix: require a usable detonation report

### DIFF
--- a/joesandboxv2_connector.py
+++ b/joesandboxv2_connector.py
@@ -37,6 +37,7 @@ except ImportError:
 from bs4 import BeautifulSoup
 
 from joesandboxv2_consts import *
+from joesandboxv2_report import get_nonempty_report_analysis
 
 
 class RetVal(tuple):
@@ -943,6 +944,10 @@ class JoeSandboxV2Connector(BaseConnector):
                 except Exception as e:
                     self._dump_error_log(e)
                     return action_result.set_status(phantom.APP_ERROR, JOE_ERR_JSON_MSG.format(error=self._get_err_msg_from_exception(e))), None
+
+        analysis_data = get_nonempty_report_analysis(response_data)
+        if analysis_data is None:
+            return action_result.set_status(phantom.APP_ERROR, JOE_ERR_EMPTY_JSON_REPORT_MSG), None
 
         # Required fields to be extracted from the response obtained
         overview_info_keys = {

--- a/joesandboxv2_consts.py
+++ b/joesandboxv2_consts.py
@@ -63,6 +63,7 @@ JOE_PCAP_REPORT_DOWNLOAD_MSG = "PCAP report downloaded successfully"
 JOE_ERR_ADDING_TO_VAULT_FAILED_MSG = "Error occurred while adding the file to vault"
 JOE_ERR_FILE_OR_COOKBOOK_NOT_FOUND_MSG = "Either the file or the cookbook for the provided hash not found in vault"
 JOE_ERR_REPORT_FILENAME_NOT_FOUND_MSG = 'Incorrect response format. Not able to find "Content-Disposition" in headers'
+JOE_ERR_EMPTY_JSON_REPORT_MSG = "The completed analysis did not return a nonempty JSON report"
 
 # JSON keys
 JOE_JSON_RESPONSE = "response"

--- a/joesandboxv2_report.py
+++ b/joesandboxv2_report.py
@@ -1,0 +1,17 @@
+from joesandboxv2_consts import JOE_JSON_ANALYSIS, JOE_JSON_RESPONSE
+
+
+def get_nonempty_report_analysis(response_data):
+    """Return the analysis object only when the report response is usable."""
+    if not isinstance(response_data, dict):
+        return None
+
+    report = response_data.get(JOE_JSON_RESPONSE)
+    if not isinstance(report, dict):
+        return None
+
+    analysis = report.get(JOE_JSON_ANALYSIS)
+    if not isinstance(analysis, dict) or not analysis:
+        return None
+
+    return analysis

--- a/joesandboxv2_report.py
+++ b/joesandboxv2_report.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from joesandboxv2_consts import (
     JOE_JSON_ANALYSIS,
     JOE_JSON_BEHAVIOR,

--- a/joesandboxv2_report.py
+++ b/joesandboxv2_report.py
@@ -1,4 +1,25 @@
-from joesandboxv2_consts import JOE_JSON_ANALYSIS, JOE_JSON_RESPONSE
+from joesandboxv2_consts import (
+    JOE_JSON_ANALYSIS,
+    JOE_JSON_BEHAVIOR,
+    JOE_JSON_DOMAIN_INFO,
+    JOE_JSON_DROPPED_INFO,
+    JOE_JSON_FILE_INFO,
+    JOE_JSON_GENERAL_INFO,
+    JOE_JSON_IP_INFO,
+    JOE_JSON_RESPONSE,
+    JOE_JSON_SIGNATURED_DETECTIONS,
+)
+
+
+USABLE_ANALYSIS_SECTIONS = (
+    JOE_JSON_GENERAL_INFO,
+    JOE_JSON_FILE_INFO,
+    JOE_JSON_DOMAIN_INFO,
+    JOE_JSON_IP_INFO,
+    JOE_JSON_SIGNATURED_DETECTIONS,
+    JOE_JSON_DROPPED_INFO,
+    JOE_JSON_BEHAVIOR,
+)
 
 
 def get_nonempty_report_analysis(response_data):
@@ -11,7 +32,7 @@ def get_nonempty_report_analysis(response_data):
         return None
 
     analysis = report.get(JOE_JSON_ANALYSIS)
-    if not isinstance(analysis, dict) or not analysis:
+    if not isinstance(analysis, dict) or not any(analysis.get(section) for section in USABLE_ANALYSIS_SECTIONS):
         return None
 
     return analysis

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 
-- Return an error when a completed detonation has no usable JSON report.
-- Require at least one populated report section before completing a detonation.
+* - Return an error when a completed detonation has no usable JSON report.
+* - Require at least one populated report section before completing a detonation.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 - Return an error when a completed detonation has no usable JSON report.
+- Require at least one populated report section before completing a detonation.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 
-* - Return an error when a completed detonation has no usable JSON report.
-* - Require at least one populated report section before completing a detonation.
+* Return an error when a completed detonation has no usable JSON report.
+* Require at least one populated report section before completing a detonation.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Return an error when a completed detonation has no usable JSON report.

--- a/tests/test_json_report_validation.py
+++ b/tests/test_json_report_validation.py
@@ -12,6 +12,10 @@ class JsonReportValidationTestCase(unittest.TestCase):
         response = {JOE_JSON_RESPONSE: {JOE_JSON_ANALYSIS: {}}}
         self.assertIsNone(get_nonempty_report_analysis(response))
 
+    def test_nonempty_but_unusable_analysis_fails(self):
+        response = {JOE_JSON_RESPONSE: {JOE_JSON_ANALYSIS: {"generalinfo": {}}}}
+        self.assertIsNone(get_nonempty_report_analysis(response))
+
     def test_nonempty_analysis_passes(self):
         analysis = {"generalinfo": {"target": "sample"}}
         response = {JOE_JSON_RESPONSE: {JOE_JSON_ANALYSIS: analysis}}

--- a/tests/test_json_report_validation.py
+++ b/tests/test_json_report_validation.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import unittest
 
 from joesandboxv2_consts import JOE_JSON_ANALYSIS, JOE_JSON_RESPONSE

--- a/tests/test_json_report_validation.py
+++ b/tests/test_json_report_validation.py
@@ -1,0 +1,22 @@
+import unittest
+
+from joesandboxv2_consts import JOE_JSON_ANALYSIS, JOE_JSON_RESPONSE
+from joesandboxv2_report import get_nonempty_report_analysis
+
+
+class JsonReportValidationTestCase(unittest.TestCase):
+    def test_missing_report_response_fails(self):
+        self.assertIsNone(get_nonempty_report_analysis({}))
+
+    def test_empty_analysis_fails(self):
+        response = {JOE_JSON_RESPONSE: {JOE_JSON_ANALYSIS: {}}}
+        self.assertIsNone(get_nonempty_report_analysis(response))
+
+    def test_nonempty_analysis_passes(self):
+        analysis = {"generalinfo": {"target": "sample"}}
+        response = {JOE_JSON_RESPONSE: {JOE_JSON_ANALYSIS: analysis}}
+        self.assertIs(get_nonempty_report_analysis(response), analysis)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject successful report responses that omit the report object
- reject report objects without a nonempty analysis structure
- cover missing, empty, and usable report responses with unit tests

This is a narrow follow-up to #28 after exact source validation found that parseable empty report responses could still complete detonation actions successfully.

## Tracking

- [PAPP-38220](https://splunk.atlassian.net/browse/PAPP-38220)
- [PSAAS-31796](https://splunk.atlassian.net/browse/PSAAS-31796)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)

## Validation

- `ruff format --check joesandboxv2_connector.py joesandboxv2_consts.py joesandboxv2_report.py tests/test_json_report_validation.py`
- `ruff check joesandboxv2_connector.py joesandboxv2_consts.py joesandboxv2_report.py tests/test_json_report_validation.py`
- `python -m unittest tests/test_json_report_validation.py`
- Python compile check
- Hosted pre-commit and compile gates pending

This pull request was written by Codex with AI assistance.

Merge strategy: merge commit only; do not squash.
